### PR TITLE
Change scoreboard font to Parchment

### DIFF
--- a/game/src/hud.js
+++ b/game/src/hud.js
@@ -7,7 +7,7 @@ var createHud = function () {
 
 	// Create a Text Block that can display the current score
 	scoreText = new BABYLON.GUI.TextBlock();
-	scoreText.fontFamily = "Comic Sans, Comic Sans MS";
+	scoreText.fontFamily = "Parchment";
 	scoreText.color = "white";
 	scoreText.fontSize = 48;
 	scoreText.verticalAlignment = BABYLON.GUI.TextBlock.VERTICAL_ALIGNMENT_TOP;


### PR DESCRIPTION
Related to #2

Updates the scoreboard font in `hud.js` from "Comic Sans, Comic Sans MS" to "Parchment".

- Changes the `fontFamily` property of `scoreText` to "Parchment", enhancing the visual appearance of the scoreboard.
- Maintains all other properties and functionalities of the scoreboard, including score display and high score tracking.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/juanpflores/CubeFly/issues/2?shareId=706ac680-e66e-4c06-a99d-7d788f11e544).